### PR TITLE
Update PrintBox.mli

### DIFF
--- a/src/PrintBox.mli
+++ b/src/PrintBox.mli
@@ -14,11 +14,11 @@
       val b : t = <abstr>
 
       # PrintBox_text.output ~indent:2 stdout b;;
-      +----------+
-      |hello     |
-      |----------|
-      |world|yolo|
-      +----------+
+        +----------+
+        |hello     |
+        |----------|
+        |world|yolo|
+        +----------+
       - : unit = ()
 
       # let b2 = PrintBox.(


### PR DESCRIPTION
add the missing spaces required by `indent`,
thus the [doc](https://c-cube.github.io/printbox/0.5/printbox/PrintBox/index.html#box-combinators) can have a correct output.