### PR TITLE
Split Printbox in three packages to make it easier to install exactly what we want

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See https://c-cube.github.io/printbox/
 Ideally, use [opam](http://opam.ocaml.org/):
 
 ```sh non-deterministic=command
-$ opam install printbox
+$ opam install printbox printbox-unicode
 ```
 
 Manually:
@@ -215,7 +215,8 @@ boxes will not cut it.
 The advice below can be replaced by simply using `printbox.unicode` with:
 
 ```ocaml non-deterministic=command
-# #require "printbox.unicode";;
+# #require "printbox-unicode";;
+# open Printbox_unicode;;
 # PrintBox_unicode.setup();;
 ```
 
@@ -278,4 +279,3 @@ Note that trees are printed in HTML using nested lists, and
 that `PrintBox_html.to_string_doc` will insert some javascript to
 make sub-lists fold/unfold on click (this is useful to display very large
 trees compactly and exploring them incrementally).
-

--- a/printbox-unicode.opam
+++ b/printbox-unicode.opam
@@ -2,23 +2,20 @@ opam-version: "2.0"
 authors: ["Simon Cruanes" "Guillaume Bury"]
 maintainer: "simon.cruanes.2007@m4x.org"
 version: "0.5"
-synopsis: "Allows to print nested boxes, lists, arrays, tables in several formats"
+synopsis: "Printbox unicode handling"
+description: """
+Adds unicode handling to the printbox package.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats
+"""
 build: [
   ["dune" "build" "@install" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune" { >= "1.1" }
-  "base-bytes"
-  "odoc" {with-doc}
-  "ocaml" { >= "4.03" }
-  "uutf" {with-test}
-  "uucp" {with-test}
-  "mdx" {with-test & >= "1.4" & < "1.6" }
-]
-depopts: [
-  "tyxml"
+  "printbox" {= version}
+  "uutf"
+  "uucp"
 ]
 tags: [ "print" "box" "table" "tree" ]
 homepage: "https://github.com/c-cube/printbox/"

--- a/src/PrintBox_text.ml
+++ b/src/PrintBox_text.ml
@@ -24,7 +24,7 @@ end = struct
     | Cyan -> 6
     | White -> 7
 
-  let codes_of_style (self:t) : int list = 
+  let codes_of_style (self:t) : int list =
     let {bold;fg_color;bg_color} = self in
     (if bold then [1] else []) @
     (match bg_color with None -> [] | Some c -> [40 + int_of_color_ c]) @
@@ -53,8 +53,8 @@ module Pos = struct
   type t = position
 
   let[@inline] compare pos1 pos2 =
-    match Pervasives.compare pos1.y pos2.y with
-    | 0 -> Pervasives.compare pos1.x pos2.x
+    match compare pos1.y pos2.y with
+    | 0 -> compare pos1.x pos2.x
     | x -> x
 
   let origin = {x=0; y=0;}

--- a/src/printbox-unicode/PrintBox_unicode.ml
+++ b/src/printbox-unicode/PrintBox_unicode.ml
@@ -1,4 +1,3 @@
-
 (** {1 Setup Unicode-aware text printing}
 
     This module just provides a function, {!setup},
@@ -14,9 +13,8 @@ let string_len s i len =
   Uutf.String.fold_utf_8 ~pos:i ~len
     (fun n _ c -> match c with
       | `Malformed _ -> 0
-      | `Uchar c -> n+ max 0 (Uucp.Break.tty_width_hint c))
+      | `Uchar c -> n + max 0 (Uucp.Break.tty_width_hint c))
     0 s
 
 let setup () =
   PrintBox_text.set_string_len string_len
-

--- a/src/printbox-unicode/dune
+++ b/src/printbox-unicode/dune
@@ -1,6 +1,4 @@
 (library
   (name printbox_unicode)
-  (public_name printbox.unicode)
-  (wrapped false)
-  (optional)
+  (public_name printbox-unicode)
   (libraries printbox uutf uucp))

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 
 (executables
   (names test1 test_ann_0_3)
-  (libraries printbox uutf uucp printbox.unicode))
+  (libraries printbox printbox-unicode))
 
 (rule
   (targets test1.output)

--- a/test/test1.ml
+++ b/test/test1.ml
@@ -96,6 +96,8 @@ let b =
   ]
 
 module Unicode = struct
+  open Printbox_unicode
+
   let () = PrintBox_unicode.setup()
 
   let b =
@@ -108,4 +110,3 @@ module Unicode = struct
 
   let () = print_endline @@ PrintBox_text.to_string b
 end
-

--- a/test/test_ann_0_3.ml
+++ b/test/test_ann_0_3.ml
@@ -1,6 +1,7 @@
 
 let b =
   let open PrintBox in
+  let open Printbox_unicode in
   PrintBox_unicode.setup();
   frame @@ grid_l [
     [text "subject"; text_with_style Style.bold "announce: printbox 0.3"];


### PR DESCRIPTION
dune is bad at looking at optional dependencies in opam and this looks like a "bad" feature in opam (at least it makes it hard to know what needs to be installed or not)

I refactored your repository to allow you to create three distinct packages thus allowing a finer control over what needs to be installed or not.

Notice that I tried to make it the smoothier I could so that anyone using one of the packages and previously already using them just has to put `open Printbox` (or `open Printbox_unicode` or `open Printbox_html`) and won't have nothing else to do.

This should be a better fix for #14 