### PR TITLE
The promised `<details>`-based solution to collapsible trees

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
           #- windows-latest
           #- macos-latest
         ocaml-compiler:
-          - 4.03.x
           - 4.08.x
           - 4.12.x
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ including:
 
 See https://c-cube.github.io/printbox/
 
+## License
+
+BSD-2-clauses
+
 ## Build
 
-Ideally, use [opam](http://opam.ocaml.org/):
+Ideally, use [opam](http://opam.ocaml.org/) with OCaml >= 4.08:
 
 ```sh non-deterministic=command
 $ opam install printbox printbox-text

--- a/README.md
+++ b/README.md
@@ -246,4 +246,16 @@ which prints some HTML in the file [foo.html](docs/foo.html).
 Note that trees are printed in HTML using nested lists, and
 that `PrintBox_html.to_string_doc` will insert some javascript to
 make sub-lists fold/unfold on click (this is useful to display very large
-trees compactly and exploring them incrementally).
+trees compactly and exploring them incrementally). But there is also
+an alternative solution where trees are printed in HTML using the
+`<details>` element. To activate it, use the `tree_summary` config:
+
+```ocaml
+# #require "printbox-html";;
+# print_endline PrintBox_html.(to_string
+  ~config:Config.(tree_summary true default)
+    B.(tree (text "0")[text "1"; tree (text "ω") [text "ω²"]]));;
+<div><details><summary><span class="">0</span></summary><ul><li><span class="">1</span></li><li><details><summary><span class="">ω</span></summary><ul><li><span class="">ω²</span></li></ul></details></li></ul></details></div>
+
+- : unit = ()
+```

--- a/printbox-html.opam
+++ b/printbox-html.opam
@@ -17,6 +17,7 @@ depends: [
   "odoc" {with-doc}
   "printbox" {= version}
   "tyxml" {>="4.3"}
+  "mdx" {with-test & >= "1.4" }
 ]
 license: "BSD-2-Clause"
 tags: [ "print" "box" "table" "tree" ]

--- a/printbox.opam
+++ b/printbox.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" { >= "2.0" }
   "base-bytes"
   "odoc" {with-doc}
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.08" }
 ]
 license: "BSD-2-Clause"
 tags: [ "print" "box" "table" "tree" ]

--- a/src/PrintBox.ml
+++ b/src/PrintBox.ml
@@ -19,14 +19,17 @@ module Style = struct
     bold: bool;
     bg_color: color option;
     fg_color: color option;
+    preformatted: bool;
   }
 
-  let default = {bold=false; bg_color=None; fg_color=None}
+  let default = {bold=false; bg_color=None; fg_color=None; preformatted=false}
   let set_bg_color c self = {self with bg_color=Some c}
   let set_fg_color c self = {self with fg_color=Some c}
   let set_bold b self = {self with bold=b}
+  let set_preformatted b self = {self with preformatted=b}
 
   let bold : t = set_bold true default
+  let preformatted : t = set_preformatted true default
   let bg_color c : t = set_bg_color c default
   let fg_color c : t = set_fg_color c default
 end

--- a/src/PrintBox.mli
+++ b/src/PrintBox.mli
@@ -77,6 +77,8 @@ module Style : sig
     bold: bool;
     bg_color: color option; (** backgroud color *)
     fg_color: color option; (** foreground color *)
+    preformatted: bool;
+    (** where supported, the text rendering should be monospaced and respect whitespace *)
   }
   (** Basic styling (color, bold).
       @since 0.3 *)
@@ -89,11 +91,15 @@ module Style : sig
 
   val set_bold : bool -> t -> t
 
+  val set_preformatted : bool -> t -> t
+
   val bg_color : color -> t
 
   val fg_color : color -> t
 
   val bold : t
+
+  val preformatted : t
 end
 
 (** {2 Box Combinators} *)

--- a/src/printbox-html/PrintBox_html.ml
+++ b/src/printbox-html/PrintBox_html.ml
@@ -28,7 +28,7 @@ let prelude_str =
 
 let attrs_of_style (s:B.Style.t) : _ list * _ =
   let open B.Style in
-  let {bold;bg_color;fg_color} = s in
+  let {bold;bg_color;fg_color;preformatted} = s in
   let encode_color = function
     | Red -> "red"
     | Blue -> "blue"
@@ -41,7 +41,8 @@ let attrs_of_style (s:B.Style.t) : _ list * _ =
   in
   let s =
     (match bg_color with None -> [] | Some c -> ["background-color", encode_color c]) @
-    (match fg_color with None -> [] | Some c -> ["color", encode_color c])
+    (match fg_color with None -> [] | Some c -> ["color", encode_color c]) @
+    (if preformatted then ["font-family", "monospace"] else [])
   in
   let a = match s with
     | [] -> []
@@ -59,7 +60,6 @@ module Config = struct
     cls_col: string list;
     a_col: Html_types.div_attrib Html.attrib list;
     tree_summary: bool;
-    preformatted: bool;
   }
 
   let default : t = {
@@ -72,7 +72,6 @@ module Config = struct
     cls_col=[];
     a_col=[];
     tree_summary=false;
-    preformatted=false;
   }
 
   let cls_table x c = {c with cls_table=x}
@@ -84,7 +83,6 @@ module Config = struct
   let cls_col x c = {c with cls_col=x}
   let a_col x c = {c with a_col=x}
   let tree_summary x c = {c with tree_summary=x}
-  let preformatted x c = {c with preformatted=x}
 end
 
 let to_html_rec ~config (b: B.t) =
@@ -99,7 +97,7 @@ let to_html_rec ~config (b: B.t) =
     fun fix b ->
       match B.view b with
       | B.Empty -> (H.div [] :> [< Html_types.flow5 > `Pre `Span `Div `P `Table `Ul ] html)
-      | B.Text {l; style} when config.preformatted -> H.pre [text_to_html ~l ~style]
+      | B.Text {l; style} when style.B.Style.preformatted -> H.pre [text_to_html ~l ~style]
       | B.Text {l; style} -> text_to_html ~l ~style
       | B.Pad (_, b)
       | B.Frame b -> fix b

--- a/src/printbox-html/PrintBox_html.ml
+++ b/src/printbox-html/PrintBox_html.ml
@@ -133,7 +133,7 @@ let to_html_rec ~config (b: B.t) =
         ]
     | B.Link _ -> assert false }
   in
-  let rec to_html_rec b : [< Html_types.flow5 > `Details `Pre `Span `Div `Ul `Table `P] html =
+  let rec to_html_rec b =
     match B.view b with
     | B.Tree (_, b, l) when config.tree_summary ->
       let l = Array.to_list l in
@@ -149,7 +149,7 @@ let to_html_rec ~config (b: B.t) =
     | B.Link {uri; inner} ->
       H.div [H.a ~a:[H.a_href uri] [to_html_nondet_rec inner]]
     | _ -> loop.loop to_html_rec b
-  and to_html_nondet_rec b : [< Html_types.flow5_without_interactive > `Pre `Span `Div `Ul `Table `P] html =
+  and to_html_nondet_rec b =
     match B.view b with
     | B.Link {uri; inner} ->
       H.div [H.a ~a:[H.a_href uri] [to_html_nondet_rec inner]]

--- a/src/printbox-html/PrintBox_html.ml
+++ b/src/printbox-html/PrintBox_html.ml
@@ -85,7 +85,7 @@ module Config = struct
 end
 
 type html_fix = {
-  loop : 'tags. (B.t -> ([< Html_types.flow5 > `Div `Ul `Table `P] as 'tags) html) -> B.t -> 'tags html
+  loop : 'tags. (B.t -> ([< Html_types.flow5 > `Span `Div `Ul `Table `P] as 'tags) html) -> B.t -> 'tags html
 }
 
 let to_html_rec ~config (b: B.t) =
@@ -100,13 +100,7 @@ let to_html_rec ~config (b: B.t) =
   let loop = { loop = fun fix b ->
     match B.view b with
     | B.Empty -> (H.div [] :> [< Html_types.flow5 > `Div `P `Table `Ul ] html)
-    | B.Text {l; style} ->
-      let a, bold = attrs_of_style style in
-      let l = List.map H.txt l in
-      let l = if bold then List.map (fun x->H.b [x]) l else l in
-      H.div
-        ~a:(H.a_class config.cls_text :: (a @ config.a_text))
-        l
+    | B.Text {l; style} -> text_to_html ~l ~style
     | B.Pad (_, b)
     | B.Frame b -> fix b
     | B.Align {h=`Right;inner=b;v=_} ->
@@ -137,7 +131,7 @@ let to_html_rec ~config (b: B.t) =
         ]
     | B.Link _ -> assert false }
   in
-  let rec to_html_rec b : [< Html_types.flow5 > `Details `Div `Ul `Table `P] html =
+  let rec to_html_rec b : [< Html_types.flow5 > `Details `Span `Div `Ul `Table `P] html =
     match B.view b with
     | B.Tree (_, b, l) when config.tree_summary ->
       let l = Array.to_list l in
@@ -145,7 +139,7 @@ let to_html_rec ~config (b: B.t) =
       | B.Text {l=tl; style} ->
         H.details (H.summary [text_to_html ~l:tl ~style])
         [ H.ul (List.map (fun x -> H.li [to_html_rec x]) l) ]
-        | _ ->
+      | _ ->
           H.div
         [ to_html_rec b
         ; H.ul (List.map (fun x -> H.li [to_html_rec x]) l)
@@ -153,7 +147,7 @@ let to_html_rec ~config (b: B.t) =
     | B.Link {uri; inner} ->
       H.div [H.a ~a:[H.a_href uri] [to_html_nondet_rec inner]]
     | _ -> loop.loop to_html_rec b
-  and to_html_nondet_rec b : [< Html_types.flow5_without_interactive > `Div `Ul `Table `P] html =
+  and to_html_nondet_rec b : [< Html_types.flow5_without_interactive > `Span `Div `Ul `Table `P] html =
     match B.view b with
     | B.Link {uri; inner} ->
       H.div [H.a ~a:[H.a_href uri] [to_html_nondet_rec inner]]

--- a/src/printbox-html/PrintBox_html.mli
+++ b/src/printbox-html/PrintBox_html.mli
@@ -32,6 +32,9 @@ module Config : sig
   val tree_summary : bool -> t -> t
   (** When set to true, the trees are rendered collapsed
       using the [<detalis>] HTML5 element. *)
+
+  val preformatted : bool -> t -> t
+  (** When set to true, text is rendered using the [<pre>] HTML element. *)
 end
 
 val to_html : ?config:Config.t -> PrintBox.t -> [`Div] html

--- a/src/printbox-html/PrintBox_html.mli
+++ b/src/printbox-html/PrintBox_html.mli
@@ -29,6 +29,9 @@ module Config : sig
   val a_row : Html_types.div_attrib Html.attrib list -> t -> t
   val cls_col : string list -> t -> t
   val a_col : Html_types.div_attrib Html.attrib list -> t -> t
+  val tree_summary : bool -> t -> t
+  (** When set to true, the trees are rendered collapsed
+      using the [<detalis>] HTML5 element. *)
 end
 
 val to_html : ?config:Config.t -> PrintBox.t -> [`Div] html

--- a/src/printbox-html/PrintBox_html.mli
+++ b/src/printbox-html/PrintBox_html.mli
@@ -32,9 +32,6 @@ module Config : sig
   val tree_summary : bool -> t -> t
   (** When set to true, the trees are rendered collapsed
       using the [<detalis>] HTML5 element. *)
-
-  val preformatted : bool -> t -> t
-  (** When set to true, text is rendered using the [<pre>] HTML element. *)
 end
 
 val to_html : ?config:Config.t -> PrintBox.t -> [`Div] html

--- a/src/printbox-text/PrintBox_text.ml
+++ b/src/printbox-text/PrintBox_text.ml
@@ -25,7 +25,7 @@ end = struct
     | White -> 7
 
   let codes_of_style (self:t) : int list =
-    let {bold;fg_color;bg_color} = self in
+    let {bold;fg_color;bg_color;preformatted=_} = self in
     (if bold then [1] else []) @
     (match bg_color with None -> [] | Some c -> [40 + int_of_color_ c]) @
     (match fg_color with None -> [] | Some c -> [30 + int_of_color_ c])


### PR DESCRIPTION
There's a new entry `tree_summary: bool` in `PrintBox_html.Config.t` to control if trees should be rendered using the `<details><summary>` elements.