### PR TITLE
PrintBox.ml: shouldn't Text store a list of non-breakable lines?

### DIFF
--- a/src/PrintBox.ml
+++ b/src/PrintBox.ml
@@ -67,8 +67,9 @@ let line_with_style style s =
 
 let line s = line_with_style Style.default s
 
-let text s = Text {l=[s]; style=Style.default}
-let text_with_style style s = Text {l=[s]; style}
+(* FIXME: does not handle '\r' *)
+let text s = Text {l=String.split_on_char '\n' s; style=Style.default}
+let text_with_style style s = Text {l=String.split_on_char '\n' s; style}
 
 let sprintf_with_style style format =
   let buffer = Buffer.create 64 in


### PR DESCRIPTION
Currently `PrintBox_text` does not assume that and splits each of the lines. But we have `PrintBox.line` and `PrintBox.lines`. The former validates the input, the latter does not. So that would also need changing maybe.