### PR TITLE
Bug fix: multiline text boxes should always be vertical

### DIFF
--- a/src/printbox-html/PrintBox_html.ml
+++ b/src/printbox-html/PrintBox_html.ml
@@ -105,17 +105,30 @@ module Config = struct
   let tree_summary x c = { c with tree_summary = x }
 end
 
+let br_lines ~bold l =
+  let l =
+    List.map H.txt @@ List.concat @@ List.map (String.split_on_char '\n') l
+  in
+  let len = List.length l in
+  List.concat
+  @@ List.mapi
+       (fun i x ->
+         (if bold then
+            H.b [ x ]
+          else
+            x)
+         ::
+         (if i < len - 1 then
+            [ H.br () ]
+          else
+            []))
+       l
+
 let to_html_rec ~config (b : B.t) =
   let open Config in
-  let h_text_to_html ?(border = false) ~l ~style () =
+  let br_text_to_html ?(border = false) ~l ~style () =
     let a, bold = attrs_of_style style in
-    let l = List.map H.txt l in
-    let l =
-      if bold then
-        List.map (fun x -> H.b [ x ]) l
-      else
-        l
-    in
+    let l = br_lines ~bold l in
     let a_border =
       if border then
         [ H.a_style "border:thin solid" ]
@@ -138,40 +151,22 @@ let to_html_rec ~config (b : B.t) =
         [ H.txt @@ String.concat "\n" l ]
     else (
       (* TODO: remove possible trailing '\r' *)
-      let l =
-        List.map H.txt @@ List.concat @@ List.map (String.split_on_char '\n') l
-      in
-      let len = List.length l in
-      let l =
-        List.concat
-        @@ List.mapi
-             (fun i x ->
-               (if bold then
-                 H.b [ x ]
-               else
-                 x)
-               ::
-               (if i < len - 1 then
-                 [ H.br () ]
-               else
-                 []))
-             l
-      in
+      let l = br_lines ~bold l in
       H.div ~a:(a_class config.cls_text @ a_border @ a @ config.a_text) l
     )
   in
-  let loop
-        : 'tags.
-          (B.t ->
-          ([< Html_types.flow5 > `Pre `Span `Div `Ul `Table `P ] as 'tags) html) ->
-          B.t ->
-          'tags html =
+  let loop :
+        'tags.
+        (B.t ->
+        ([< Html_types.flow5 > `Pre `Span `Div `Ul `Table `P ] as 'tags) html) ->
+        B.t ->
+        'tags html =
    fun fix b ->
     match B.view b with
     | B.Empty ->
       (H.div [] :> [< Html_types.flow5 > `Pre `Span `Div `P `Table `Ul ] html)
     | B.Text { l; style } when style.B.Style.preformatted ->
-      H.pre [ h_text_to_html ~l ~style () ]
+      v_text_to_html ~l ~style ()
     | B.Text { l; style } -> v_text_to_html ~l ~style ()
     | B.Pad (_, b) -> fix b
     | B.Frame b -> H.div ~a:[ H.a_style "border:thin solid" ] [ fix b ]
@@ -206,13 +201,13 @@ let to_html_rec ~config (b : B.t) =
       (match B.view b with
       | B.Text { l = tl; style } ->
         H.details
-          (H.summary [ h_text_to_html ~l:tl ~style () ])
+          (H.summary [ br_text_to_html ~l:tl ~style () ])
           [ H.ul (List.map (fun x -> H.li [ to_html_rec x ]) l) ]
       | B.Frame b ->
         (match B.view b with
         | B.Text { l = tl; style } ->
           H.details
-            (H.summary [ h_text_to_html ~border:true ~l:tl ~style () ])
+            (H.summary [ br_text_to_html ~border:true ~l:tl ~style () ])
             [ H.ul (List.map (fun x -> H.li [ to_html_rec x ]) l) ]
         | _ ->
           H.div

--- a/src/printbox-md/README.md
+++ b/src/printbox-md/README.md
@@ -45,7 +45,7 @@ or if \`Bars are set, |  by the | vertical dash.
 <div>
  <table class="non-framed">
   <tr><td><div>Otherwise, the fallback behavior is as if</div></td>
-   <td><pre><span style="font-family: monospace">`As_table</span></pre></td>
+   <td><pre style="font-family: monospace">`As_table</pre></td>
    <td><div>was used to configure horizontal boxes.</div></td>
   </tr>
  </table>
@@ -143,14 +143,13 @@ Rows  |[must be]|single    |line.
    <td>
     <div style="border:thin solid"><div><b>Markdown's native</b></div></div>
    </td><td><div>restrictions,</div></td><td><div>special cases:</div></td>
-   <td><pre><span style="font-family: monospace">hlistvlist</span></pre></td>
+   <td><pre style="font-family: monospace">hlist
+                                           vlist</pre></td>
   </tr>
   <tr><td><div>End up</div></td><td><div>as either</div></td>
    <td><div>of the fallbacks:</div></td>
-   <td>
-    <pre>
-     <span style="font-family: monospace">printbox-textprintbox-html</span>
-    </pre>
+   <td><pre style="font-family: monospace">printbox-text
+                                           printbox-html</pre>
    </td>
   </tr>
  </table>

--- a/test/test_md.expected
+++ b/test/test_md.expected
@@ -132,7 +132,11 @@ Test uniform unfolded:
     - \<returns\>
       - `<nothing>`
     - & \*\*subchild\*\* 4
-- <div><div style="border:thin solid"><div><pre><span style="font-family: monospace">header 5</span></pre><ul><li><pre><span style="font-family: monospace">subchild 5  body 5    subbody 5	one tab end of sub 5end of 5</span></pre></li></ul></div></div></div>
+- <div><div style="border:thin solid"><div><pre style="font-family: monospace">header 5</pre><ul><li><pre style="font-family: monospace">subchild 5
+  body 5
+    subbody 5
+	one tab end of sub 5
+end of 5</pre></li></ul></div></div></div>
   
   
 - <div><div style="border:thin solid"><div style="border:thin solid"><table class="framed"><tr><td><div>a</div></td><td><div>looooooooooooooooooooooooo<br/>oonng</div></td></tr><tr><td><div>bx</div></td><td><div class="center"><div style="border:thin solid"><table class="framed"><tr><td><div>x</div></td><td><div>y</div></td></tr><tr><td><div>1</div></td><td><div>2</div></td></tr></table></div></div></td></tr><tr><td><div>?</div></td><td><div class="center"><table class="framed"><tr><td><div>x</div></td><td><div>y</div></td></tr><tr><td><div>10</div></td><td><div>20</div></td></tr></table></div></td></tr></table></div></div></div>

--- a/test/test_md.expected.md
+++ b/test/test_md.expected.md
@@ -132,7 +132,11 @@ Test uniform unfolded:
     - \<returns\>
       - `<nothing>`
     - & \*\*subchild\*\* 4
-- <div><div style="border:thin solid"><div><pre><span style="font-family: monospace">header 5</span></pre><ul><li><pre><span style="font-family: monospace">subchild 5  body 5    subbody 5	one tab end of sub 5end of 5</span></pre></li></ul></div></div></div>
+- <div><div style="border:thin solid"><div><pre style="font-family: monospace">header 5</pre><ul><li><pre style="font-family: monospace">subchild 5
+  body 5
+    subbody 5
+	one tab end of sub 5
+end of 5</pre></li></ul></div></div></div>
   
   
 - <div><div style="border:thin solid"><div style="border:thin solid"><table class="framed"><tr><td><div>a</div></td><td><div>looooooooooooooooooooooooo<br/>oonng</div></td></tr><tr><td><div>bx</div></td><td><div class="center"><div style="border:thin solid"><table class="framed"><tr><td><div>x</div></td><td><div>y</div></td></tr><tr><td><div>1</div></td><td><div>2</div></td></tr></table></div></div></td></tr><tr><td><div>?</div></td><td><div class="center"><table class="framed"><tr><td><div>x</div></td><td><div>y</div></td></tr><tr><td><div>10</div></td><td><div>20</div></td></tr></table></div></td></tr></table></div></div></div>


### PR DESCRIPTION
I was too hasty and missed regressions visible in the test expectations we already had. Apologies.