### PR TITLE
Pass configuration to `printbox-text` extensions: whether ANSI styling is allowed

### DIFF
--- a/src/printbox-ext-plot/PrintBox_ext_plot.ml
+++ b/src/printbox-ext-plot/PrintBox_ext_plot.ml
@@ -55,7 +55,8 @@ let plot_canvas ?canvas ?(size : (int * int) option) ?(sparse = false)
   let (dimx, dimy, canvas) : int * int * (int * B.t) list array array =
     (* The integer in the cells is the priority number: lower number = more visible. *)
     match canvas, size with
-    | None, None -> invalid_arg "PrintBox_ext_plot.plot: provide ~canvas or ~size"
+    | None, None ->
+      invalid_arg "PrintBox_ext_plot.plot: provide ~canvas or ~size"
     | None, Some (dimx, dimy) -> dimx, dimy, Array.make_matrix dimy dimx []
     | Some canvas, None ->
       let dimy = Array.length canvas in
@@ -244,8 +245,8 @@ let plot_canvas ?canvas ?(size : (int * int) option) ?(sparse = false)
 
 let concise_float = ref (fun ~prec -> Printf.sprintf "%.*g" prec)
 
-let plot ~prec ~axes ?canvas ?size ~x_label
-    ~y_label ~sparse embed_canvas specs =
+let plot ~prec ~axes ?canvas ?size ~x_label ~y_label ~sparse embed_canvas specs
+    =
   let minx, miny, maxx, maxy, canvas =
     plot_canvas ?canvas ?size ~sparse specs
   in
@@ -356,7 +357,8 @@ let text_based_handler ~render ext =
            specs)
   | _ -> invalid_arg "PrintBox_ext_plot.text_handler: unrecognized extension"
 
-let text_handler = text_based_handler ~render:PrintBox_text.to_string
+let text_handler ~style =
+  text_based_handler ~render:(PrintBox_text.to_string_with ~style)
 
 let md_handler config =
   text_based_handler ~render:(PrintBox_md.to_string config)

--- a/src/printbox-text/PrintBox_text.ml
+++ b/src/printbox-text/PrintBox_text.ml
@@ -564,7 +564,7 @@ end = struct
           Text { l = List.rev !acc; style; link_with_uri = Some uri }
         | B.Ext { key; ext } ->
           (match Hashtbl.find_opt extensions key with
-          | Some handler -> (of_box ~ansi @@ B.text @@ handler ext).shape
+          | Some handler -> (of_box ~ansi @@ B.text @@ handler ~style:ansi ext).shape
           | None ->
             failwith @@ "PrintBox_html.to_html: missing extension handler for "
             ^ key))
@@ -585,7 +585,7 @@ end = struct
         self.shape
       | B.Ext { key; ext } ->
         (match Hashtbl.find_opt extensions key with
-        | Some handler -> (of_box ~ansi @@ B.text @@ handler ext).shape
+        | Some handler -> (of_box ~ansi @@ B.text @@ handler ~style:ansi ext).shape
         | None ->
           failwith @@ "PrintBox_html.to_html: missing extension handler for "
           ^ key)

--- a/src/printbox-text/PrintBox_text.mli
+++ b/src/printbox-text/PrintBox_text.mli
@@ -5,8 +5,10 @@
     This module should be used to output boxes directly to a terminal, or
     another  area of monospace text *)
 
-val register_extension : key:string -> (PrintBox.ext -> string) -> unit
+val register_extension :
+  key:string -> (style:bool -> PrintBox.ext -> string) -> unit
 (** Add support for the extension with the given key to this rendering backend.
+    If [style = true], the extension can use ANSI codes for styling.
     Note: the string returned by the handler can have line breaks. *)
 
 val set_string_len : (String.t -> int -> int -> int) -> unit


### PR DESCRIPTION
Apologies, I forgot to include that earlier.