### PR TITLE
Fix HTML backend: it was impossible to provide extension support within summary (and link body) fields

### DIFF
--- a/src/printbox-html/PrintBox_html.ml
+++ b/src/printbox-html/PrintBox_html.ml
@@ -255,7 +255,9 @@ let to_html_rec ~config (b : B.t) =
     | B.Tree (_, b, l) ->
       let l = Array.to_list l in
       H.div [ fix b; H.ul (List.map (fun x -> H.li [ fix x ]) l) ]
-    | B.Anchor _ | B.Link _ | B.Ext _ -> assert false
+    | B.Anchor _ -> assert false
+     | B.Link _ -> assert false
+     | B.Ext _ -> assert false
   in
 
   let rec to_html_rec b =

--- a/src/printbox-html/PrintBox_html.mli
+++ b/src/printbox-html/PrintBox_html.mli
@@ -6,14 +6,24 @@ open Tyxml
 
 type 'a html = 'a Html.elt
 type toplevel_html = Html_types.li_content_fun html
+type summary_html = Html_types.span_content_fun html
 
 type PrintBox.ext +=
   | Embed_html of toplevel_html
         (** Injects HTML into a box. It is handled natively by [PrintBox_html].
             NOTE: this extension is unlikely to be supported by other backends! *)
+  | Embed_summary_html of summary_html
+        (** Injects HTML intended for tree nodes into a box.
+            It is handled natively by [PrintBox_html].
+            NOTE: this extension is unlikely to be supported by other backends! *)
+
 
 val embed_html : toplevel_html -> PrintBox.t
 (** Injects HTML into a box. NOTE: this is unlikely to be supported by other backends! *)
+
+val embed_summary_html : summary_html -> PrintBox.t
+(** Injects HTML intended for tree nodes into a box.
+    NOTE: this is unlikely to be supported by other backends! *)
 
 val prelude : [> Html_types.style ] html
 (** HTML text to embed in the "<head>", defining the style for tables *)
@@ -47,8 +57,20 @@ val register_extension :
   key:string -> (Config.t -> PrintBox.ext -> toplevel_html) -> unit
 (** Add support for the extension with the given key to this rendering backend. *)
 
+val register_summary_extension :
+  key:string -> (Config.t -> PrintBox.ext -> summary_html) -> unit
+(** Add support for the extension with the given key to this rendering backend. *)
+
 val to_html : ?config:Config.t -> PrintBox.t -> [ `Div ] html
 (** HTML for one box *)
+
+exception Summary_not_supported
+(** Raised by {!to_summary_html} if the box cannot be rendered suitably
+    for a summary part of the details element. *)
+
+val to_summary_html : ?config:Config.t -> PrintBox.t -> summary_html
+(** HTML suitable for tree nodes. Raises {!Summary_not_supported} if the box
+    cannot be rendered in this form. *)
 
 val pp :
   ?flush:bool ->

--- a/src/printbox-html/PrintBox_html.mli
+++ b/src/printbox-html/PrintBox_html.mli
@@ -7,6 +7,7 @@ open Tyxml
 type 'a html = 'a Html.elt
 type toplevel_html = Html_types.li_content_fun html
 type summary_html = Html_types.span_content_fun html
+type link_html = Html_types.flow5_without_interactive html
 
 type PrintBox.ext +=
   | Embed_html of toplevel_html
@@ -16,13 +17,20 @@ type PrintBox.ext +=
         (** Injects HTML intended for tree nodes into a box.
             It is handled natively by [PrintBox_html].
             NOTE: this extension is unlikely to be supported by other backends! *)
-
+  | Embed_link_html of link_html
+        (** Injects HTML intended for link bodies.
+            It is handled natively by [PrintBox_html].
+            NOTE: this extension is unlikely to be supported by other backends! *)
 
 val embed_html : toplevel_html -> PrintBox.t
 (** Injects HTML into a box. NOTE: this is unlikely to be supported by other backends! *)
 
 val embed_summary_html : summary_html -> PrintBox.t
 (** Injects HTML intended for tree nodes into a box.
+    NOTE: this is unlikely to be supported by other backends! *)
+
+val embed_link_html : link_html -> PrintBox.t
+(** Injects HTML intended for link bodies into a box.
     NOTE: this is unlikely to be supported by other backends! *)
 
 val prelude : [> Html_types.style ] html
@@ -61,6 +69,10 @@ val register_summary_extension :
   key:string -> (Config.t -> PrintBox.ext -> summary_html) -> unit
 (** Add support for the extension with the given key to this rendering backend. *)
 
+val register_link_extension :
+  key:string -> (Config.t -> PrintBox.ext -> link_html) -> unit
+(** Add support for the extension with the given key to this rendering backend. *)
+
 val to_html : ?config:Config.t -> PrintBox.t -> [ `Div ] html
 (** HTML for one box *)
 
@@ -70,6 +82,14 @@ exception Summary_not_supported
 
 val to_summary_html : ?config:Config.t -> PrintBox.t -> summary_html
 (** HTML suitable for tree nodes. Raises {!Summary_not_supported} if the box
+    cannot be rendered in this form. *)
+
+exception Link_not_supported
+(** Raised by {!to_link_html} if the box cannot be rendered suitably
+    for a link body. *)
+
+val to_link_html : ?config:Config.t -> PrintBox.t -> link_html
+(** HTML suitable for link bodies. Raises {!Link_not_supported} if the box
     cannot be rendered in this form. *)
 
 val pp :

--- a/test/extend_html_specific.expected
+++ b/test/extend_html_specific.expected
@@ -6,3 +6,7 @@ HTML output simple:
 HTML output with header:
 <div><div><details><summary><span>Greetings!</span></summary><ul><li><button>Hello wide world!</button></li></ul></details></div></div>
 
+
+HTML output with details and summary:
+<div><details><summary><span><span style="border:thin dotted"><span style="border:thin dotted"><span>Greetings!</span></span>&nbsp;<span style="border:thin dotted"><button>Hello wide world!</button></span></span></span></summary><ul><li><button>Hello world!</button></li><li><div><details><summary><span>Greetings!</span></summary><ul><li><button>Hello wide world!</button></li></ul></details></div></li></ul></details></div>
+

--- a/test/extend_html_specific.ml
+++ b/test/extend_html_specific.ml
@@ -18,17 +18,35 @@ let html_handler config ext =
       :> PrintBox_html.toplevel_html)
   | _ -> invalid_arg "html_handler: unknown extension"
 
+let summary_handler config ext =
+  match ext with
+  | Hello_html txt -> (H.button [ H.txt txt ] :> PrintBox_html.summary_html)
+  | Hello_with_header txt ->
+      let result = H.button [ H.txt txt ] in
+      (PrintBox_html.to_summary_html ~config
+         B.(
+           hlist ~bars:true [text "Greetings!"
+             ; B.extension ~key:"Embed_summary_html" (PrintBox_html.Embed_summary_html result) ])
+        :> PrintBox_html.summary_html)
+    | _ -> invalid_arg "html_handler: unknown extension"
+  
 let () =
-  PrintBox_html.register_extension ~key:"Hello_world" html_handler
+  PrintBox_html.register_extension ~key:"Hello_world" html_handler;
+  PrintBox_html.register_summary_extension ~key:"Hello_world" summary_handler
 
 let test1 = B.extension ~key:"Hello_world" @@ Hello_html "Hello world!"
 
 let test2 =
   B.extension ~key:"Hello_world" @@ Hello_with_header "Hello wide world!"
 
+let test3 = B.tree test2 [test1; test2]
+
 let () =
   print_endline "\nHTML output simple:";
   print_endline @@ PrintBox_html.to_string test1;
   print_endline "\nHTML output with header:";
   print_endline
-  @@ PrintBox_html.(to_string ~config:Config.(tree_summary true default) test2)
+  @@ PrintBox_html.(to_string ~config:Config.(tree_summary true default) test2);
+  print_endline "\nHTML output with details and summary:";
+  print_endline
+  @@ PrintBox_html.(to_string ~config:Config.(tree_summary true default) test3)


### PR DESCRIPTION
Since we work with TyXML, we need separate entries for the differently-typed sections of documents.
Here it's done with separate registrations -- there are design alternatives to still register just one function, e.g. GADT.
This PR also refactors `PrintBox_html` a bit.